### PR TITLE
require types, classic way

### DIFF
--- a/source/lib/types/index.js
+++ b/source/lib/types/index.js
@@ -1,9 +1,15 @@
-let fs = require('fs');
-let path = require('path');
-let dirItems = fs.readdirSync(__dirname);
-
-dirItems.forEach((i) => {
-    if (i !== 'index.js' && i.substr(i.length - 3, 3) === '.js') {
-        module.exports[i.substr(0, i.length - 3)] = require(path.resolve(__dirname, i));
-    }
-});
+module.exports.alignment = require('./alignment.js');
+module.exports.borderStyle = require('./borderStyle.js');
+module.exports.cellComment = require('./cellComment.js');
+module.exports.colorScheme = require('./colorScheme.js');
+module.exports.excelColor = require('./excelColor.js');
+module.exports.fillPattern = require('./fillPattern.js');
+module.exports.fontFamily = require('./fontFamily.js');
+module.exports.index = require('./index.js');
+module.exports.orientation = require('./orientation.js');
+module.exports.pageOrder = require('./pageOrder.js');
+module.exports.pane = require('./pane.js');
+module.exports.paneState = require('./paneState.js');
+module.exports.paperSize = require('./paperSize.js');
+module.exports.positiveUniversalMeasure = require('./positiveUniversalMeasure.js');
+module.exports.printError = require('./printError.js');


### PR DESCRIPTION
```
let fs = require('fs');
let path = require('path');
let dirItems = fs.readdirSync(__dirname);

dirItems.forEach((i) => {
    if (i !== 'index.js' && i.substr(i.length - 3, 3) === '.js') {
        module.exports[i.substr(0, i.length - 3)] = require(path.resolve(__dirname, i));
    }
}); 
```

dynamic import make a crash in webpack environment. some hacks can make build success, but I think basically good library must easy to use.